### PR TITLE
Stripped general/targeted and added table copy

### DIFF
--- a/src/components/GrantsCategories/index.vue
+++ b/src/components/GrantsCategories/index.vue
@@ -6,19 +6,18 @@
             <MainHeading title="categories.heading" />
         </div>
         <Paragraph text="categories.body.p1" />
-        <SubHeading title="categories.general.heading" />
-        <Paragraph text="categories.general.body.p1" />
-        <SubHeading title="categories.targeted.heading" />
-        <Paragraph text="categories.targeted.body.p2" />
-        <!--Types-->
         <SubHeading title="categories.types.heading" />
+        <GrantCategoriesTable/>
     </section>
 
 </template>
+
+
 <script>
 import MainHeading from '@/components/Comman/MainHeading';
 import SubHeading from '@/components/Comman/SubHeading';
 import Paragraph from '@/components/Comman/Paragraph';
+import GrantCategoriesTable from './table.vue';
 
 export default {
     name: "GrantCategories",
@@ -26,7 +25,7 @@ export default {
         MainHeading,
         SubHeading,
         Paragraph,
-
+        GrantCategoriesTable
     }
 }
 </script>

--- a/src/components/GrantsCategories/table.vue
+++ b/src/components/GrantsCategories/table.vue
@@ -1,0 +1,77 @@
+
+
+<template>
+  <table
+    class="rounded-[5px] overflow-hidden border-t-4 border-b-[12px] border-l-4 border-r-4 text-base mx-auto sm:w-tableDesktopWidth ml-tableMobile mr-tableMobile xs:ml-0 xs:mr-0 pr-9 bg-tableBackground font-dmSans md:text-lg rounded mt-12 md:border-r-fourty md:border-l-fourty">
+    <thead>
+      <tr>
+        <TH text="about.table.tableHeading1" />
+        <TH text="about.table.tableHeading2" />
+        <TH text="about.table.tableHeading3" />
+        <TH text="about.table.tableHeading4" />
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <TD text="about.table.tableCol1-1" />
+        <TD text="about.table.tableCol2-1" />
+        <TD text="about.table.tableCol3-1" />
+        <TD text="about.table.tableCol4-1" />
+      </tr>
+      <tr>
+        <TD text="about.table.tableCol1-2" />
+        <TD text="about.table.tableCol2-2" />
+        <TD text="about.table.tableCol3-2" />
+        <TD text="about.table.tableCol4-4" />
+      </tr>
+      <tr>
+        <TD text="about.table.tableCol1-3" />
+        <TD text="about.table.tableCol2-3" />
+        <TD text="about.table.tableCol3-3" />
+        <TD text="about.table.tableCol4-3" />
+      </tr>
+      <tr class="bg-parrotGreen font-bold">
+        <TD text="about.table.tableCol1-4" />
+        <TD text="about.table.tableCol2-4" />
+        <TD text="about.table.tableCol3-4" />
+        <TD text="about.table.tableCol4-4" />
+      </tr>
+      <tr>
+        <TD text="about.table.tableCol1-5" />
+        <TD text="about.table.tableCol2-5" />
+        <TD text="about.table.tableCol3-5" />
+        <TD text="about.table.tableCol4-5" />
+      </tr>
+      <tr>
+        <TD text="about.table.tableCol1-6" />
+        <TD text="about.table.tableCol2-6" />
+        <TD text="about.table.tableCol3-6" />
+        <TD text="about.table.tableCol4-6" />
+      </tr>
+      <tr>
+        <TD text="about.table.tableCol1-7" />
+        <TD text="about.table.tableCol2-7" />
+        <TD text="about.table.tableCol3-7" />
+        <TD text="about.table.tableCol4-7" />
+      </tr>
+      <tr>
+        <TD text="about.table.tableCol1-8" />
+        <TD text="about.table.tableCol2-8" />
+        <TD text="about.table.tableCol3-8" />
+        <TD text="about.table.tableCol4-8" />
+      </tr>
+    </tbody>
+  </table>
+</template>
+
+<script>
+import TH from '@/components/Comman/TH'
+import TD from '@/components/Comman/TD'
+export default {
+  name: "Table",
+  components: {
+    TH,
+    TD
+  },
+}
+</script>

--- a/src/components/Navbar/LeftSideBar/index.vue
+++ b/src/components/Navbar/LeftSideBar/index.vue
@@ -56,22 +56,6 @@
       <div class="text-headingsColor pt-6 pl-1">
         <a
           class="font-notoSans text-textColor text-base font-normal"
-          href="#categories.general"
-        >
-          {{ $t("categories.general.nav-heading") }}
-        </a>
-      </div>
-      <div class="text-headingsColor pt-6 pl-1">
-        <a
-          class="font-notoSans text-textColor text-base font-normal"
-          href="#categories.targeted"
-        >
-          {{ $t("categories.targeted.nav-heading") }}
-        </a>
-      </div>
-      <div class="text-headingsColor pt-6 pl-1">
-        <a
-          class="font-notoSans text-textColor text-base font-normal"
           href="#categories.types"
         >
           {{ $t("categories.types.nav-heading") }}

--- a/src/locales/cn.json
+++ b/src/locales/cn.json
@@ -1,6 +1,6 @@
 {
 
-  "etc-grants-dao": {
+  "c": {
     "title": "ETC Grants DAO",
     "description": "We provide funding for promising projects that will invigorate the Ethereum Classic ecosystem.",
     "apply-now": "Apply Now"
@@ -82,27 +82,9 @@
       "p1": "每个团队的最高资助额一般为$50,000，除非以社区资助(最高$10,000)或溢价资助(超过$50,000)申请。"
     },
 
-    "general": {
-      "heading": "一般助款",
-      "nav-heading": "一般助款",
-      "body": {
-        "p1": "一般助款对所有希望在ETC上建立项目的个人和团队都是开放的。有一个建议列表，但所有的选择都是公开的。我们欢迎您就如何增加价值提出创造性的建议。"
-      }
-    },
-
-    "targeted": {
-      "heading": "针对助款",
-      "nav-heading": "针对助款",
-      "body": {
-        "p1": "针对助款，是指那些已被奖助金评选委员会和社区选定为优先项目和增长领域并且有公开请求的助款金。随着优先级的改变和团队启动他们的项目，每一轮的拨款可能会因项目而改变。",
-        "p2": "在新的一轮开始前，可能不会有任何公开的请求。在这种情况下，该类别属于一般赠款。"  
-      }
-    },
-
     "types": {
       "heading": "助款种类",
-      "nav-heading": "助款种类",
-      "DIAGRAM_HERE": "xxx"
+      "nav-heading": "助款种类"
     }
   },
 

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -83,27 +83,9 @@
       "p1": "The maximum funding per team for grants is generally $50,000, unless applying under a community grant (maximum of $10,000) or a premium grant (those over $50,000)."
     },
 
-    "general": {
-      "heading": "General grants",
-      "nav-heading": "General",
-      "body": {
-        "p1": "General grants are open to all and any teams looking to build their projects on ETC, with anything they would like to propose. There is a list of suggestions, but all options are the on the table. We welcome your creative suggestions on how to add value."
-      }
-    },
-
-    "targeted": {
-      "heading": "Targeted grants",
-      "nav-heading": "Targeted",
-      "body": {
-        "p1": "Targeted grants are those that have been selected by the grant selection committee and community as priority items and growth areas and which have an open request. These items may or may not change each grant round, as priorities change and teams launch their projects.",
-        "p2": "There may not be any open requests at the beginning of a new round. In that case, general grants should be selected for the category."  
-      }
-    },
-
     "types": {
       "heading": "Types of grant",
-      "nav-heading": "Types",
-      "DIAGRAM_HERE": "xxx"
+      "nav-heading": "Types"
     }
   },
 

--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -35,15 +35,6 @@
             class="pt-6 font-notoSans text-headingsColor text-2xl font-bold leading-rightHeadingsDt">
             {{ $t("categories.nav-heading") }}
           </a>
-          <p class="font-notoSans text-textColor text-base font-normal pb-4">
-            {{ $t("categories.general.nav-heading") }}
-          </p>
-          <p class="font-notoSans text-textColor text-base font-normal pb-4">
-            {{ $t("categories.targeted.nav-heading") }}
-          </p>
-          <p class="font-notoSans text-textColor text-base font-normal pb-4">
-            {{ $t("categories.types.nav-heading") }}
-          </p>
 
           <!-- Requirements mobile nav -->
           <a v-on:click="closeNav()" href="#requirements"


### PR DESCRIPTION
We are not using general and targeted anymore.  Stripped all that out.   Copied the Table.vue for the grant types table to be filled into.