### PR TITLE
Added the airtable links into translation text

### DIFF
--- a/src/components/Hero/index.vue
+++ b/src/components/Hero/index.vue
@@ -12,9 +12,9 @@
               class="text-heroTextMobile md:text-heroTextDesktop text-headingsColor leading-heroText pt-6 pb-6 font-dmSans pl-8 pr-8 md:pl-0 md:pr-0">
               {{ $t("etc-grants-dao.description") }}
             </p>
-            <a href="https://airtable.com/shr3VMqyLd1HX5ws4"
+            <a href="https://airtable.com/shr3VMqyLd1HX5ws4?prefill_Form%20Language=English?prefill_Form%20Language=English"
               class="text-xl font-bold md:text-heroTextMobile mx-auto md:mx-0 px-5 py-3 rounded text-headingsColor bg-gradient-to-r from-[#133706] to-[#53EB45] font-notoSans w-heroButtonMobileWidth md:w-heroButtonDesktopWidth heroButton flex hover:scale-110 transition duration-300 ease-in-out">
-              <p>{{ $t("etc-grants-dao.apply-now") }}</p>
+              <p>{{ $t("etc-grants-dao.apply-now-text") }}</p>
               <img src="@/images/applyButtonIcon.png"
                 class="max-w-heroBtnIcon max-h-heroBtnIcon ml-heroBtnIcon mt-heroBtnIconA" />
             </a>

--- a/src/components/Navbar/NavBar/index.vue
+++ b/src/components/Navbar/NavBar/index.vue
@@ -34,9 +34,9 @@
             $t("suggestions.nav-heading")
           }}</a>
 
-        <a href="https://airtable.com/shr3VMqyLd1HX5ws4"
+        <a href="https://airtable.com/shr3VMqyLd1HX5ws4?prefill_Form%20Language=English"
           class="relative hidden lg:block font-notoSans font-semibold px-5 py-2 rounded text-headingsColor border-2 text-lg topApplyNow">
-          {{ $t("etc-grants-dao.apply-now") }}</a>
+          {{ $t("etc-grants-dao.apply-now-text") }}</a>
 
         <!-- English/Chinese toggle-->
         <div class="my-auto text-black">

--- a/src/locales/cn.json
+++ b/src/locales/cn.json
@@ -3,7 +3,8 @@
   "c": {
     "title": "ETC Grants DAO",
     "description": "We provide funding for promising projects that will invigorate the Ethereum Classic ecosystem.",
-    "apply-now": "Apply Now"
+    "apply-now-text": "Apply Now",
+    "apply-now-link": "https://airtable.com/shr3VMqyLd1HX5ws4?prefill_Form%20Language=English?prefill_Form%20Language=%E4%B8%AD%E5%9B%BD%E4%BA%BA"
   },
 
   "contents-title": "Contents",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -3,7 +3,8 @@
   "etc-grants-dao": {
     "title": "ETC Grants DAO",
     "description": "We provide funding for promising projects that will invigorate the Ethereum Classic ecosystem.",
-    "apply-now": "Apply Now"
+    "apply-now-text": "Apply Now",
+    "apply-now-link": "https://airtable.com/shr3VMqyLd1HX5ws4?prefill_Form%20Language=English?prefill_Form%20Language=English"
   },
 
   "contents-title": "Contents",

--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -11,10 +11,10 @@
           <div class="">
             <img src="@/images/Cross.svg" v-on:click="closeNav()" class="ml-auto" id="menuIcon" ref="navClose" />
           </div>
-          <a href="https://airtable.com/shr3VMqyLd1HX5ws4"
+          <a href="https://airtable.com/shr3VMqyLd1HX5ws4?prefill_Form%20Language=English"
             class="py-1 mt-11 text-black text-center bg-gradient-to-r from-[#133706] to-[#53EB45] font-notoSans text-base font-bold rounded">
             <span class="text-headingsColor applyNowBtn relative">
-              {{ $t("etc-grants-dao.apply-now") }}
+              {{ $t("etc-grants-dao.apply-now-text") }}
             </span>
           </a>
 
@@ -117,13 +117,13 @@
             <!-- Apply Now form at bottom of page -->
             <a href=""
               class="mx-auto md:mx-0 px-5 py-3 rounded text-headingsColor bg-gradient-to-r from-[#133706] to-[#53EB45] font-notoSans w-rightSecButton text-xl leading-twentyFour hidden lg:flex mt-8 hover:scale-110 transition duration-300 ease-in-out">
-              <p>{{ $t("etc-grants-dao.apply-now") }}</p>
+              <p>{{ $t("etc-grants-dao.apply-now-text") }}</p>
               <img src="@/images/applyButtonIcon.png"
                 class="max-w-heroBtnIcon max-h-heroBtnIcon ml-heroBtnIcon mt-heroBtnIcon2" />
             </a>
-            <a href="https://airtable.com/shr3VMqyLd1HX5ws4"
+            <a href="https://airtable.com/shr3VMqyLd1HX5ws4?prefill_Form%20Language=English"
               class="text-base md:text-heroTextMobile mt-8 md:mx-0 px-5 py-3 rounded text-headingsColor bg-gradient-to-r from-[#133706] to-[#53EB45] font-notoSans w-heroButtonMobileWidth md:w-heroButtonDesktopWidth heroButton flex lg:hidden">
-              <p>{{ $t("etc-grants-dao.apply-now") }}</p>
+              <p>{{ $t("etc-grants-dao.apply-now-text") }}</p>
               <img src="@/images/applyButtonIcon.png"
                 class="max-w-heroBtnIcon max-h-heroBtnIcon ml-heroBtnIcon mt-heroBtnIcon1" />
             </a>


### PR DESCRIPTION
Switched the Apply Now URL to point to the airtable form with English defaulted.   I cannot work out how to have translation expansions for the a elements's href attribute, but that will be the next step here.