### PR TITLE
Tweaked Gabriel's link support

### DIFF
--- a/src/components/Common/Paragraph/index.vue
+++ b/src/components/Common/Paragraph/index.vue
@@ -1,5 +1,5 @@
 <template>
-    <div class="pt-12">
+    <div class="pt-6">
         <p
           v-if="!isTextContainingLink"
           class="font-roboto text-textColor text-base md:text-heroTextMobile md:leading-thirtyThree righttSecText">
@@ -29,10 +29,10 @@ export default {
                 if (val.includes(`"`)) {
                     const regExp = /\"(.*?)\"/
                     const key = (regExp.exec(val))[1];
-                    const linkText = this.$t(key);
-                    const link = this.$t(`${key}-href`);
+                    const linkText = this.$t(`${key}-text`);
+                    const linkUrl = this.$t(`${key}-url`);
 
-                    const html = `<a href=${link} class="cursor-pointer underline text-parrotGreen"><span>${linkText}</span></a>
+                    const html = `<a href=${linkUrl} class="cursor-pointer underline text-parrotGreen"><span>${linkText}</span></a>
                     `;
 
                     return html;

--- a/src/components/Overview/index.vue
+++ b/src/components/Overview/index.vue
@@ -31,8 +31,6 @@
             <SubHeading title="overview.etc-grants-program.heading" />
             <Paragraph text="overview.etc-grants-program.body.p1" />
             <Paragraph text="overview.etc-grants-program.body.p2" />
-            <Paragraph text="ethereum-classic.text" />
-            <Paragraph text="ethereum-classic-test-two.text" />
         </section>
 
     </section>

--- a/src/components/Process/index.vue
+++ b/src/components/Process/index.vue
@@ -15,6 +15,10 @@
                     <li> {{ $t("grantsProcess.phases.step1.phasesSummary.bullets.b3") }} </li>
                 </ul>
             </div>
+
+            <Paragraph text="ethereum-classic.text" />
+            <Paragraph text="ethereum-classic-test-two.text" />
+
         </div>
 
         <!--Step 2-->

--- a/src/locales/cn.json
+++ b/src/locales/cn.json
@@ -1,4 +1,29 @@
 {
+
+  "ethereum-classic": {
+    "text": "The Chinese ETC Grants program was first announced \"ethereum-classic.link-wdms\" in November 2022 to support the growth \"ethereum-classic.link-etc\" ecosystem.",
+    "link-wdms-text": "at the WDMS conference",
+    "link-wdms-url": "https://etccooperative.org/posts/2022-11-16-outline-of-xmei-lins-and-bob-summerwills-speeches-at-bitmain-wdsm-global-2022-cn",
+    "link-etc-text": "Ethereum Classic",
+    "link-etc-url": "https://ethereumclassic.org/zh/"
+  },
+
+  "ethereum-classic-test-two": {
+    "text": "ETC has the largest market cap for any proof-of-work smart contract platform, but its application ecosystem does not yet reflect that value proposition. It is listed on \"ethereum-classic-test-two.link-exchange\" and hundreds of millions of dollars of $ETC are traded daily but there are very \"ethereum-classic-test-two.link-dapps\" using the platform, only a very small amount of \"ethereum-classic-test-two.link-tvl\" in its Defi ecosystem and \"ethereum-classic-test-two.link-nft\" .",
+
+    "link-exchange-text": "every major exchange",
+    "link-exchange-url": "https://coinmarketcap.com/currencies/ethereum-classic/markets/",
+
+    "link-dapps-text": "few decentralized applications",
+    "link-dapps-url": "https://ethereumclassic.org/services/apps",
+
+    "link-tvl-text": "TVL",
+    "link-tvl-url": "https://defillama.com/chain/EthereumClassic",
+
+    "link-nft-text": " few NFT projects",
+    "link-nft-url": "https://etcplanets.com/"
+  },
+
   "etc-grants-dao": {
     "title": "ETC Grants DAO助款项目",
     "description": "我们为有前途的项目提供资金，这些项目将振兴以太坊经典生态系统。",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1,23 +1,27 @@
 {
 
   "ethereum-classic": {
-    "text": "The ETC Grants program was first announced \"ethereum-classic.link-title-one\" in November 2022 to support the growth \"ethereum-classic.link-title-two\" ecosystem.",
-    "link-title-one": "at the WDMS conference",
-    "link-title-two": "Ethereum Classic",
-    "link-title-one-href": "https://etccooperative.org/posts/2022-11-16-outline-of-xmei-lins-and-bob-summerwills-speeches-at-bitmain-wdsm-global-2022-en",
-    "link-title-two-href": "https://ethereumclassic.org/"
+    "text": "The ETC Grants program was first announced \"ethereum-classic.link-wdms\" in November 2022 to support the growth \"ethereum-classic.link-etc\" ecosystem.",
+    "link-wdms-text": "at the WDMS conference",
+    "link-wdms-url": "https://etccooperative.org/posts/2022-11-16-outline-of-xmei-lins-and-bob-summerwills-speeches-at-bitmain-wdsm-global-2022-en",
+    "link-etc-text": "Ethereum Classic",
+    "link-etc-url": "https://ethereumclassic.org/"
   },
 
   "ethereum-classic-test-two": {
-    "text": "ETC has the largest market cap for any proof-of-work smart contract platform, but its application ecosystem does not yet reflect that value proposition. It is listed on \"ethereum-classic-test-two.link-title-one\" and hundreds of millions of dollars of $ETC are traded daily but there are very \"ethereum-classic-test-two.link-title-two\" using the platform, only a very small amount of \"ethereum-classic-test-two.link-title-three\" in its Defi ecosystem and \"ethereum-classic-test-two.link-title-four\" .",
-    "link-title-one": "every major exchange",
-    "link-title-two": "few decentralized applications",
-    "link-title-three": "TVL",
-    "link-title-four": " few NFT projects",
-    "link-title-one-href": "https://coinmarketcap.com/currencies/ethereum-classic/markets/",
-    "link-title-two-href": "https://ethereumclassic.org/services/apps",
-    "link-title-three-href": "https://defillama.com/chain/EthereumClassic",
-    "link-title-four-href": "https://etcplanets.com/"
+    "text": "ETC has the largest market cap for any proof-of-work smart contract platform, but its application ecosystem does not yet reflect that value proposition. It is listed on \"ethereum-classic-test-two.link-exchange\" and hundreds of millions of dollars of $ETC are traded daily but there are very \"ethereum-classic-test-two.link-dapps\" using the platform, only a very small amount of \"ethereum-classic-test-two.link-tvl\" in its Defi ecosystem and \"ethereum-classic-test-two.link-nft\" .",
+
+    "link-exchange-text": "every major exchange",
+    "link-exchange-url": "https://coinmarketcap.com/currencies/ethereum-classic/markets/",
+
+    "link-dapps-text": "few decentralized applications",
+    "link-dapps-url": "https://ethereumclassic.org/services/apps",
+
+    "link-tvl-text": "TVL",
+    "link-tvl-url": "https://defillama.com/chain/EthereumClassic",
+
+    "link-nft-text": " few NFT projects",
+    "link-nft-url": "https://etcplanets.com/"
   },
   
   "etc-grants-dao": {


### PR DESCRIPTION
Slightly different naming convention, and moved the example into the Process sub-section which at least seemed to be working for Chinese.

The broken Chinese is a different global issue.  I will dig into that next.