### PR TITLE
Fixed typos in airtable links

### DIFF
--- a/src/locales/cn.json
+++ b/src/locales/cn.json
@@ -4,7 +4,7 @@
     "title": "ETC Grants DAO助款项目",
     "description": "我们为有前途的项目提供资金，这些项目将振兴以太坊经典生态系统。",
     "apply-now-text": "立即申请",
-    "apply-now-link": "https://airtable.com/shr3VMqyLd1HX5ws4?prefill_Form%20Language=English?prefill_Form%20Language=%E4%B8%AD%E5%9B%BD%E4%BA%BA"
+    "apply-now-link": "https://airtable.com/shr3VMqyLd1HX5ws4?prefill_Form%20Language=%E4%B8%AD%E5%9B%BD%E4%BA%BA"
   },
 
   "contents-title": "目录",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -28,7 +28,7 @@
     "title": "ETC Grants DAO",
     "description": "We provide funding for promising projects that will invigorate the Ethereum Classic ecosystem.",
     "apply-now-text": "Apply Now",
-    "apply-now-link": "https://airtable.com/shr3VMqyLd1HX5ws4?prefill_Form%20Language=English?prefill_Form%20Language=English"
+    "apply-now-link": "https://airtable.com/shr3VMqyLd1HX5ws4?prefill_Form%20Language=English"
   },
 
   "contents-title": "Contents",


### PR DESCRIPTION
These correct the URLs, but the buttons are still not doing localization directly, because the three links to airtable in the website aren't using these fields.  They are just hard-coded to the English links.  I will make an issue to track this.